### PR TITLE
fix: polyfill for IE and precision

### DIFF
--- a/src/Result/Question/Responses/Responses.js
+++ b/src/Result/Question/Responses/Responses.js
@@ -42,7 +42,7 @@ const Responses = ({ length, responseValues }) => (
           <div style={styles.measurement}>
             <Bar percentage={calculatePercentage(responseValues[value], length)} />
             <div style={styles.percent}>
-              {calculatePercentage(responseValues[value], length) * 100}%
+              {(calculatePercentage(responseValues[value], length) * 100).toFixed(2)}%
             </div>
           </div>
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+require('babel-polyfill')
+
 import React from 'react'
 import { render } from 'react-dom'
 import { AppContainer } from 'react-hot-loader'


### PR DESCRIPTION
- babel-polyfill for IE issue
- rounding to 2 decimal places
    - should we use decimaljs?